### PR TITLE
Add specialized parsing functions for portable pdb blobs

### DIFF
--- a/src/config.cmake.in
+++ b/src/config.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/dnmdlib.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/dnmdpdb.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/dnmdinterfaces.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/dnmdinterfaces_static.cmake")
 

--- a/src/config.cmake.in
+++ b/src/config.cmake.in
@@ -1,8 +1,6 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/dnmdlib.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/dnmdpdb.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/dnmdinterfaces.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/dnmdinterfaces_static.cmake")
 
 check_required_components(dnmd)

--- a/src/dnmd/CMakeLists.txt
+++ b/src/dnmd/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(dnmd_pdb
 )
 
 target_compile_definitions(dnmd_pdb PUBLIC DNMD_PORTABLE_PDB)
+target_sources(dnmd_pdb PRIVATE ../inc/dnmd_pdb.h pdb_blobs.c)
 
 add_library(dnmd::dnmd ALIAS dnmd)
 add_library(dnmd::pdb ALIAS dnmd_pdb)

--- a/src/dnmd/CMakeLists.txt
+++ b/src/dnmd/CMakeLists.txt
@@ -21,12 +21,24 @@ add_library(dnmd
   ${SOURCES}
   ${HEADERS}
 )
+add_library(dnmd_pdb
+  STATIC
+  ${SOURCES}
+  ${HEADERS}
+)
+
+target_compile_definitions(dnmd_pdb PUBLIC DNMD_PORTABLE_PDB)
 
 add_library(dnmd::dnmd ALIAS dnmd)
+add_library(dnmd::pdb ALIAS dnmd_pdb)
 
 target_include_directories(dnmd PUBLIC $<INSTALL_INTERFACE:include>)
+target_include_directories(dnmd_pdb PUBLIC $<INSTALL_INTERFACE:include>)
 
 set_target_properties(dnmd PROPERTIES
+  PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp")
+
+set_target_properties(dnmd_pdb PROPERTIES
   PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp")
 
 install(TARGETS dnmd EXPORT dnmd
@@ -34,5 +46,12 @@ install(TARGETS dnmd EXPORT dnmd
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
+  
+install(TARGETS dnmd_pdb EXPORT pdb
+  PUBLIC_HEADER DESTINATION include
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
 
 install(EXPORT dnmd NAMESPACE dnmd:: FILE dnmdlib.cmake DESTINATION lib/cmake/dnmd)
+install(EXPORT pdb NAMESPACE dnmd:: FILE dnmdpdb.cmake DESTINATION lib/cmake/dnmd)

--- a/src/dnmd/CMakeLists.txt
+++ b/src/dnmd/CMakeLists.txt
@@ -39,7 +39,7 @@ set_target_properties(dnmd PROPERTIES
   PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp")
 
 set_target_properties(dnmd_pdb PROPERTIES
-  PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp")
+  PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp;../inc/dnmd_pdb.h")
 
 install(TARGETS dnmd EXPORT dnmd
   PUBLIC_HEADER DESTINATION include

--- a/src/dnmd/CMakeLists.txt
+++ b/src/dnmd/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(dnmd_pdb
 
 target_compile_definitions(dnmd_pdb PUBLIC DNMD_PORTABLE_PDB)
 target_sources(dnmd_pdb PRIVATE ../inc/dnmd_pdb.h pdb_blobs.c)
+set_target_properties(dnmd_pdb PROPERTIES EXPORT_NAME pdb)
 
 add_library(dnmd::dnmd ALIAS dnmd)
 add_library(dnmd::pdb ALIAS dnmd_pdb)
@@ -42,17 +43,10 @@ set_target_properties(dnmd PROPERTIES
 set_target_properties(dnmd_pdb PROPERTIES
   PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp;../inc/dnmd_pdb.h")
 
-install(TARGETS dnmd EXPORT dnmd
-  PUBLIC_HEADER DESTINATION include
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-  
-install(TARGETS dnmd_pdb EXPORT pdb
+install(TARGETS dnmd dnmd_pdb EXPORT dnmd
   PUBLIC_HEADER DESTINATION include
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
 install(EXPORT dnmd NAMESPACE dnmd:: FILE dnmdlib.cmake DESTINATION lib/cmake/dnmd)
-install(EXPORT pdb NAMESPACE dnmd:: FILE dnmdpdb.cmake DESTINATION lib/cmake/dnmd)

--- a/src/dnmd/bytes.c
+++ b/src/dnmd/bytes.c
@@ -29,6 +29,11 @@ bool advance_stream(uint8_t const** data, size_t* data_len, size_t b)
     return true;
 }
 
+bool advance_output_stream(uint8_t** data, size_t* data_len, size_t b)
+{
+    return advance_stream((uint8_t const**)data, data_len, b);
+}
+
 // This is a little-endian format in the physical form.
 static bool read_le(uint8_t const** data, size_t* data_len, void* o, size_t o_size)
 {

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -452,6 +452,41 @@ static bool dump_table_rows(mdtable_t* table)
                     free(sequence_points);
                     continue;
                 }
+                else if (table->table_id == mdtid_LocalConstant && col == mdtLocalConstant_Signature)
+                {
+                    if (i == 32)
+                    {
+                        printf("");
+                    }
+                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
+                    md_local_constant_sig_t* local_constant_sig;
+                    size_t local_constant_sig_len;
+                    IF_INVALID_BLOB_REPORT_RAW(md_parse_local_constant_sig, table->cxt, "LocalConstantSig", local_constant_sig, local_constant_sig_len);
+                    printf("LocalConstantSig: ");
+                    for (uint32_t k = 0; k < local_constant_sig->custom_modifier_count; ++k)
+                    {
+                        printf("%s(0x%08x) ", local_constant_sig->custom_modifiers[k].required ? "modreq" : "modopt", local_constant_sig->custom_modifiers[k].type);
+                    }
+
+                    if (local_constant_sig->constant_kind == mdck_PrimitiveConstant)
+                    {
+                        printf("Primitive: 0x%02x ", local_constant_sig->primitive.type_code);
+                    }
+                    else if (local_constant_sig->constant_kind == mdck_EnumConstant)
+                    {
+                        printf("Enum: 0x%02x{0x%08x (mdToken)} ", local_constant_sig->enum_constant.type_code, local_constant_sig->enum_constant.enum_type);
+                    }
+                    else if (local_constant_sig->constant_kind == mdck_GeneralConstant)
+                    {
+                        printf("General: 0x%02x{0x%08x (mdToken)} ", local_constant_sig->general.kind, local_constant_sig->general.type);
+                    }
+                    else
+                    {
+                        assert(!"Invalid constant kind.");
+                    }
+                    printf("Value Offset: %zu (len: %zu) [%#x]|", local_constant_sig->value_blob - table->cxt->blob_heap.ptr, local_constant_sig->value_len, raw_values[j]);
+                    continue;
+                }
 #endif
                 IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
                 printf("Offset: %zu (len: %u) [%#x]|", (blob - table->cxt->blob_heap.ptr), blob_len, raw_values[j]);

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -345,6 +345,7 @@ static bool dump_table_rows(mdtable_t* table)
 
 #define IF_NOT_ONE_REPORT_RAW(exp) if (1 != (exp)) { printf("Invalid (%u) [%#x]|", j, raw_values[j]); continue; }
 #define IF_INVALID_BLOB_REPORT_RAW(parse_fn, handle_or_cursor, blob_type, result_buf, result_buf_len) \
+    { \
     result_buf = NULL; \
     md_blob_parse_result_t result = parse_fn(handle_or_cursor, blob, blob_len, result_buf, &result_buf_len); \
     if (result == mdbpr_InvalidBlob) { printf("Invalid PDB Blob (" blob_type ") Offset: %zu (len: %u) [%#x]|", (blob - table->cxt->blob_heap.ptr), blob_len, raw_values[j]); continue; } \
@@ -353,7 +354,8 @@ static bool dump_table_rows(mdtable_t* table)
     if (result_buf == NULL) { printf("Ran out of memory when parsing PDB blob.\n"); return false; } \
     result = parse_fn(handle_or_cursor, blob, blob_len, result_buf, &result_buf_len); \
     if (result == mdbpr_InvalidBlob) { printf("Invalid PDB Blob (" blob_type ") Offset: %zu (len: %u) [%#x]|", (blob - table->cxt->blob_heap.ptr), blob_len, raw_values[j]); free(result_buf); continue; } \
-    assert(result == mdbpr_Success) \
+    assert(result == mdbpr_Success); \
+    }
 
     for (uint32_t i = 0; i < table->row_count; ++i)
     {

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -389,7 +389,7 @@ static bool dump_table_rows(mdtable_t* table)
 #ifdef DNMD_PORTABLE_PDB
                 if (table->table_id == mdtid_Document && col == mdtDocument_Name)
                 {
-                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
+                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, col, 1, &blob, &blob_len));
                     
                     char* document_name;
                     size_t name_len;
@@ -400,7 +400,7 @@ static bool dump_table_rows(mdtable_t* table)
                 }
                 else if (table->table_id == mdtid_MethodDebugInformation && col == mdtMethodDebugInformation_SequencePoints)
                 {
-                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
+                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, col, 1, &blob, &blob_len));
                     
                     if (blob_len == 0)
                     {
@@ -456,7 +456,7 @@ static bool dump_table_rows(mdtable_t* table)
                 }
                 else if (table->table_id == mdtid_LocalConstant && col == mdtLocalConstant_Signature)
                 {
-                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
+                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, col, 1, &blob, &blob_len));
                     md_local_constant_sig_t* local_constant_sig;
                     size_t local_constant_sig_len;
                     IF_INVALID_BLOB_REPORT_RAW(md_parse_local_constant_sig, table->cxt, "LocalConstantSig", local_constant_sig, local_constant_sig_len);
@@ -489,7 +489,7 @@ static bool dump_table_rows(mdtable_t* table)
                 }
                 else if (table->table_id == mdtid_ImportScope && col == mdtImportScope_Imports)
                 {
-                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
+                    IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, col, 1, &blob, &blob_len));
                     
                     if (blob_len == 0)
                     {
@@ -550,7 +550,7 @@ static bool dump_table_rows(mdtable_t* table)
                     continue;
                 }
 #endif
-                IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, IDX(j), 1, &blob, &blob_len));
+                IF_NOT_ONE_REPORT_RAW(md_get_column_value_as_blob(cursor, col, 1, &blob, &blob_len));
                 printf("Offset: %zu (len: %u) [%#x]|", (blob - table->cxt->blob_heap.ptr), blob_len, raw_values[j]);
             }
             else if (table->column_details[j] & mdtc_hus)

--- a/src/dnmd/internal.h
+++ b/src/dnmd/internal.h
@@ -8,6 +8,9 @@
 #include <string.h>
 #include <corhdr.h>
 #include <dnmd.h>
+#ifdef DNMD_PORTABLE_PDB
+#include <dnmd_pdb.h>
+#endif
 
 // Implementations for missing bounds checking APIs.
 // See https://en.cppreference.com/w/c/error#Bounds_checking
@@ -391,6 +394,8 @@ bool read_u32(uint8_t const** data, size_t* data_len, uint32_t* o);
 bool read_i32(uint8_t const** data, size_t* data_len, int32_t* o);
 bool read_u64(uint8_t const** data, size_t* data_len, uint64_t* o);
 bool read_i64(uint8_t const** data, size_t* data_len, int64_t* o);
+
+bool advance_output_stream(uint8_t** data, size_t* data_len, size_t b);
 
 bool write_u8(uint8_t** data, size_t* data_len, uint8_t o);
 bool write_i8(uint8_t** data, size_t* data_len, int8_t o);

--- a/src/dnmd/pdb_blobs.c
+++ b/src/dnmd/pdb_blobs.c
@@ -79,3 +79,198 @@ md_blob_parse_result_t md_parse_document_name(mdhandle_t handle, uint8_t const* 
     *name_len = required_len;
     return result;
 }
+
+// We only support up to UINT32_MAX - 1 sequence points per method.
+// Technically, the number of supported sequence points in the spec is unbounded.
+// However, the PE format that an ECMA-335 blob is commonly wrapped in
+// can only support up to 4GB files, so we can't possibly have UINT32_MAX - 1 entries
+// in any existing scenario anyway.
+static uint32_t get_num_sequence_points(mdcursor_t debug_info_row, uint8_t const* blob, size_t blob_len)
+{
+    uint32_t num_records = 0;
+    uint32_t ignored;
+    if (!decompress_u32(&blob, &blob_len, &ignored)) // header LocalSignature
+        return UINT32_MAX;
+    
+    mdcursor_t document;
+    if (1 != md_get_column_value_as_cursor(debug_info_row, mdtMethodDebugInformation_Document, 1, &document))
+        return UINT32_MAX;
+
+    if (CursorNull(&document) && !decompress_u32(&blob, &blob_len, &ignored)) // header InitialDocument
+        return UINT32_MAX;
+
+    bool first_record = true;
+    while (blob_len > 0)
+    {
+        if (num_records == UINT32_MAX)
+            return UINT32_MAX;
+        num_records++;
+        uint32_t il_offset;
+        if (!decompress_u32(&blob, &blob_len, &il_offset)) // ILOffset
+            return UINT32_MAX;
+        
+        // The first record cannot be a document record
+        if (!first_record && il_offset == 0)
+        {
+            uint32_t document_offset;
+            if (!decompress_u32(&blob, &blob_len, &document_offset)) // Document
+                return UINT32_MAX;
+        }
+        else
+        {
+            // We don't need to check if we need to do an unsigned or signed decompression
+            // as we will always read the same number of bytes and we don't care about the values here
+            // as we're only calculating the number of records.
+            uint32_t delta_lines;
+            if (!decompress_u32(&blob, &blob_len, &delta_lines)) // DeltaLines
+                return UINT32_MAX;
+            
+            uint32_t delta_columns;
+            if (!decompress_u32(&blob, &blob_len, &delta_columns)) // DeltaColumns
+                return UINT32_MAX;
+            if (delta_lines != 0 || delta_columns != 0)
+            {
+                uint32_t start_line;
+                if (!decompress_u32(&blob, &blob_len, &start_line)) // StartLine
+                    return UINT32_MAX;
+                uint32_t start_column;
+                if (!decompress_u32(&blob, &blob_len, &start_column)) // StartColumn
+                    return UINT32_MAX;
+            }
+        }
+
+        first_record = false;
+    }
+
+    return num_records;
+}
+
+md_blob_parse_result_t md_parse_sequence_points(mdcursor_t debug_info_row, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len)
+{
+    if (CursorNull(&debug_info_row) || CursorEnd(&debug_info_row))
+        return mdbpr_InvalidArgument;
+    
+    if (blob == NULL || buffer_len == NULL)
+        return mdbpr_InvalidArgument;
+
+    uint32_t num_records = get_num_sequence_points(debug_info_row, blob, blob_len);
+
+    if (num_records == UINT32_MAX)
+        return mdbpr_InvalidBlob;
+    
+    size_t required_size = sizeof(md_sequence_points_t) + num_records * sizeof(sequence_points->records[0]);
+    if (sequence_points == NULL || *buffer_len < required_size)
+    {
+        *buffer_len = required_size;
+        return mdbpr_InsufficientBuffer;
+    }
+
+    // header LocalSignature
+    if (!decompress_u32(&blob, &blob_len, &sequence_points->signature))
+        return mdbpr_InvalidBlob;
+    
+    mdcursor_t document;
+    if (1 != md_get_column_value_as_cursor(debug_info_row, mdtMethodDebugInformation_Document, 1, &document))
+        return mdbpr_InvalidBlob;
+
+    // Create a "null" cursor to default-initialize the document field.
+    mdcxt_t* cxt = extract_mdcxt(md_extract_handle_from_cursor(debug_info_row));
+    sequence_points->document = create_cursor(&cxt->tables[mdtid_Document], 0);
+    
+    // header InitialDocument
+    uint32_t document_rid = 0;
+    if (CursorNull(&document) && !decompress_u32(&blob, &blob_len, &document_rid))
+        return mdbpr_InvalidBlob;
+    
+    if (document_rid != 0
+        && !md_token_to_cursor(cxt, CreateTokenType(mdtid_Document) | document_rid, &sequence_points->document))
+        return mdbpr_InvalidBlob;
+
+    bool seen_non_hidden_sequence_point = false;
+    for (uint32_t i = 0; blob_len > 0 && i < num_records; ++i)
+    {
+        uint32_t il_offset;
+        if (!decompress_u32(&blob, &blob_len, &il_offset)) // ILOffset
+            return mdbpr_InvalidBlob;
+        if (i != 0 && il_offset == 0)
+        {
+            uint32_t document_row_id;
+            if (!decompress_u32(&blob, &blob_len, &document_row_id)) // Document
+                return mdbpr_InvalidBlob;
+            
+            sequence_points->records[i].kind = mdsp_DocumentRecord;
+            if (!md_token_to_cursor(cxt, CreateTokenType(mdtid_Document) | document_row_id, &sequence_points->records[i].document.document))
+                return mdbpr_InvalidBlob;
+        }
+        else
+        {
+            uint32_t delta_lines;
+            if (!decompress_u32(&blob, &blob_len, &delta_lines)) // DeltaLines
+                return mdbpr_InvalidBlob;
+
+            int64_t delta_columns;
+            if (delta_lines == 0)
+            {
+                uint32_t raw_delta_columns;
+                if (!decompress_u32(&blob, &blob_len, &raw_delta_columns)) // DeltaColumns
+                    return mdbpr_InvalidBlob;
+                delta_columns = raw_delta_columns;
+            }
+            else
+            {
+                int32_t raw_delta_columns;
+                if (!decompress_i32(&blob, &blob_len, &raw_delta_columns)) // DeltaColumns
+                    return mdbpr_InvalidBlob;
+                delta_columns = raw_delta_columns;
+            }
+
+            if (delta_columns == 0)
+            {
+                sequence_points->records[i].kind = mdsp_HiddenSequencePointRecord;
+                sequence_points->records[i].hidden_sequence_point.il_offset = il_offset;
+            }
+            else if (!seen_non_hidden_sequence_point)
+            {
+                seen_non_hidden_sequence_point = true;
+                uint32_t start_line;
+                if (!decompress_u32(&blob, &blob_len, &start_line)) // StartLine
+                    return mdbpr_InvalidBlob;
+                uint32_t start_column;
+                if (!decompress_u32(&blob, &blob_len, &start_column)) // StartColumn
+                    return mdbpr_InvalidBlob;
+                
+                sequence_points->records[i].kind = mdsp_SequencePointRecord;
+                sequence_points->records[i].sequence_point.il_offset = il_offset;
+                sequence_points->records[i].sequence_point.num_lines = delta_lines;
+                sequence_points->records[i].sequence_point.delta_columns = delta_columns;
+                sequence_points->records[i].sequence_point.start_line = start_line;
+                sequence_points->records[i].sequence_point.start_column = start_column;
+            }
+            else
+            {
+                // If we've seen a non-hidden sequence point,
+                // then the values are compressed signed integers instead of
+                // unsigned integers.
+                int32_t start_line;
+                if (!decompress_i32(&blob, &blob_len, &start_line)) // StartLine
+                    return mdbpr_InvalidBlob;
+                int32_t start_column;
+                if (!decompress_i32(&blob, &blob_len, &start_column)) // StartColumn
+                    return mdbpr_InvalidBlob;
+
+                sequence_points->records[i].kind = mdsp_SequencePointRecord;
+                sequence_points->records[i].sequence_point.il_offset = il_offset;
+                sequence_points->records[i].sequence_point.num_lines = delta_lines;
+                sequence_points->records[i].sequence_point.delta_columns = delta_columns;
+                sequence_points->records[i].sequence_point.start_line = start_line;
+                sequence_points->records[i].sequence_point.start_column = start_column;
+            }
+        }
+    }
+
+    if (!blob_len == 0)
+        return mdbpr_InvalidBlob;
+    
+    sequence_points->record_count = num_records;
+    return mdbpr_Success;
+}

--- a/src/dnmd/pdb_blobs.c
+++ b/src/dnmd/pdb_blobs.c
@@ -1,0 +1,81 @@
+#include "internal.h"
+
+md_blob_parse_result_t md_parse_document_name(mdhandle_t handle, uint8_t const* blob, size_t blob_len, char const* name, size_t* name_len)
+{
+    mdcxt_t* cxt = extract_mdcxt(handle);
+    if (cxt == NULL)
+        return mdbpr_InvalidArgument;
+
+    if (blob == NULL || name_len == NULL)
+        return mdbpr_InvalidArgument;
+
+    // Only support one-character ASCII seperators.
+    // System.Reflection.Metadata.MetadataReader has the same limitation
+    uint8_t separator;
+    if (!read_u8(&blob, &blob_len, &separator))
+        return mdbpr_InvalidBlob;
+    
+    if (separator > 0x7f)
+        return mdbpr_InvalidBlob;
+    
+    uint8_t* name_current = (uint8_t*)name;
+    size_t remaining_name_len = *name_len;
+    size_t required_len = 0;
+    md_blob_parse_result_t result = mdbpr_Success;
+    bool write_separator = false;
+    while (blob_len > 0)
+    {
+        if (write_separator)
+        {
+            // Add the required space for the separator.
+            // If there is space in the buffer, write the separator.
+            required_len += 1;
+            if (name_current == NULL || remaining_name_len == 0)
+            {
+                result = mdbpr_InsufficientBuffer;
+            }
+            else
+            {
+                write_u8(&name_current, &remaining_name_len, separator);
+            }
+        }
+        write_separator = separator != 0;
+
+        // Get the next part of the path.
+        uint32_t part_offset;
+        if (!decompress_u32(&blob, &blob_len, &part_offset))
+            return mdbpr_InvalidBlob;
+        
+        // The part blob is a UTF-8 string that is not null-terminated.
+        const uint8_t* part;
+        uint32_t part_len;
+        if (!try_get_blob(cxt, part_offset, &part, &part_len))
+            return mdbpr_InvalidBlob;
+        
+        // Add the required space for the part.
+        // If there is space in the buffer, write the part.
+        required_len += part_len;
+        if (name_current == NULL || remaining_name_len < part_len)
+        {
+            result = mdbpr_InsufficientBuffer;
+            continue;
+        }
+        else
+        {
+            memcpy(name_current, part, part_len);
+            bool success = advance_output_stream(&name_current, &remaining_name_len, part_len);
+            assert(success);
+            (void)success;
+        }
+    }
+
+    // Add the null terminator.
+    required_len++;
+    if (name_current != NULL && remaining_name_len > 0)
+        write_u8(&name_current, &remaining_name_len, 0);
+    else
+        result = mdbpr_InsufficientBuffer;
+
+    *name_len = required_len;
+    return result;
+}

--- a/src/dnmd/tables.c
+++ b/src/dnmd/tables.c
@@ -698,7 +698,7 @@ bool initialize_table_details(
     case mdtid_MethodDebugInformation:
         table->column_details[mdtMethodDebugInformation_Document] = compute_table_index(TABLE_INDEX_ARGS(mdtid_MethodDebugInformation));
         table->column_details[mdtMethodDebugInformation_SequencePoints] = blob_index;
-        assert(mdtField_ColCount == get_table_column_count(id));
+        assert(mdtMethodDebugInformation_ColCount == get_table_column_count(id));
         break;
     case mdtid_LocalScope:
         table->column_details[mdtLocalScope_Method] = compute_table_index(TABLE_INDEX_ARGS(mdtid_MethodDef));

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -1,0 +1,42 @@
+#ifndef _SRC_INC_DNMD_PDB_H
+#define _SRC_INC_DNMD_PDB_H
+
+#include <dnmd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Methods to parse specialized blob formats defined in the Portable PDB spec.
+// https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md
+
+// Parse a DocumentName blob into a UTF-8 string.
+bool md_parse_document_name(uint8_t const* blob, size_t blob_len, char const** name, size_t* name_len);
+
+// Parse a SequencePoints blob.
+typedef struct md_sequence_points__ md_sequence_points_t;
+bool md_parse_sequence_points(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
+
+// Parse a LocalConstantSig blob.
+typedef struct md_local_constant_sig__ md_local_constant_sig_t;
+bool md_parse_local_constant_sig(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_local_constant_sig_t* local_constant_sig, size_t* buffer_len);
+
+// Parse an Imports blob.
+typedef struct md_imports__ md_imports_t;
+bool md_parse_imports(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_imports_t* imports, size_t* buffer_len);
+
+// Parse an Edit-and-Continue Local Slot Map blob.
+typedef struct md_enc_local_slot_map__ md_enc_local_slots_map_t;
+bool md_parse_enc_local_slot_map(uint8_t const* blob, size_t blob_len, md_enc_local_slot_map_t* local_slot_map, size_t* buffer_len);
+
+// Parse an Edit-and-Continue Lambda and Closure Map blob.
+typedef struct md_enc_lambda_and_closure_map__ md_enc_lambda_and_closure_map_t;
+bool md_parse_enc_lambda_and_closure_map(uint8_t const* blob, size_t blob_len, md_enc_lambda_and_closure_map_t* lambda_and_closure_map, size_t* buffer_len);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _SRC_INC_DNMD_PDB_H
+

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -31,9 +31,9 @@ typedef struct md_sequence_points__
     {
         enum
         {
-            DocumentRecord,
-            SequencePointRecord,
-            HiddenSequencePointRecord,
+            mdsp_DocumentRecord,
+            mdsp_SequencePointRecord,
+            mdsp_HiddenSequencePointRecord,
         } kind;
         union
         {
@@ -45,7 +45,7 @@ typedef struct md_sequence_points__
             {
                 uint32_t il_offset;
                 uint32_t num_lines;
-                int64_t num_columns;
+                int64_t delta_columns;
                 int64_t start_line;
                 int64_t start_column;
             } sequence_point;
@@ -56,7 +56,7 @@ typedef struct md_sequence_points__
         };
     } records[];
 } md_sequence_points_t;
-md_blob_parse_result_t md_parse_sequence_points(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
+md_blob_parse_result_t md_parse_sequence_points(mdcursor_t debug_info_row, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
 
 // Parse a LocalConstantSig blob.
 typedef struct md_local_constant_sig__

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -10,28 +10,148 @@ extern "C" {
 // Methods to parse specialized blob formats defined in the Portable PDB spec.
 // https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md
 
+typedef enum md_blob_parse_result__
+{
+    mdbpr_Success,
+    mdbpr_InvalidBlob,
+    mdbpr_InvalidArgument,
+    mdbpr_InsufficientBuffer
+} md_blob_parse_result_t;
+
 // Parse a DocumentName blob into a UTF-8 string.
-bool md_parse_document_name(uint8_t const* blob, size_t blob_len, char const** name, size_t* name_len);
+md_blob_parse_result_t md_parse_document_name(mdhandle_t handle, uint8_t const* blob, size_t blob_len, char const* name, size_t* name_len);
 
 // Parse a SequencePoints blob.
-typedef struct md_sequence_points__ md_sequence_points_t;
-bool md_parse_sequence_points(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
+typedef struct md_sequence_points__
+{
+    mdToken signature;
+    mdcursor_t document;
+    uint32_t record_count;
+    struct
+    {
+        enum
+        {
+            DocumentRecord,
+            SequencePointRecord,
+            HiddenSequencePointRecord,
+        } kind;
+        union
+        {
+            struct
+            {
+                mdcursor_t document;
+            } document;
+            struct
+            {
+                uint32_t il_offset;
+                uint32_t num_lines;
+                int64_t num_columns;
+                int64_t start_line;
+                int64_t start_column;
+            } sequence_point;
+            struct
+            {
+                uint32_t il_offset;
+            } hidden_sequence_point;
+        };
+    } records[];
+} md_sequence_points_t;
+md_blob_parse_result_t md_parse_sequence_points(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
 
 // Parse a LocalConstantSig blob.
-typedef struct md_local_constant_sig__ md_local_constant_sig_t;
-bool md_parse_local_constant_sig(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_local_constant_sig_t* local_constant_sig, size_t* buffer_len);
+typedef struct md_local_constant_sig__
+{
+    enum
+    {
+        PrimitiveConstant,
+        EnumConstant,
+        GeneralConstant
+    } constant_kind;
+
+    union
+    {
+        struct
+        {
+            uint8_t type_code;
+        } primitive;
+
+        struct
+        {
+            uint8_t type_code;
+            mdToken enum_type;
+        } enum_constant;
+
+        struct
+        {
+            enum
+            {
+                ValueType,
+                Class,
+                Object
+            } kind;
+            mdToken type;
+        } general;
+    };
+
+    const uint8_t* value_blob;
+    const uint32_t value_len;
+    
+    struct {
+        bool required;
+        mdToken type;
+    } custom_modifiers[];
+} md_local_constant_sig_t;
+md_blob_parse_result_t md_parse_local_constant_sig(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_local_constant_sig_t* local_constant_sig, size_t* buffer_len);
 
 // Parse an Imports blob.
-typedef struct md_imports__ md_imports_t;
-bool md_parse_imports(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_imports_t* imports, size_t* buffer_len);
+typedef struct md_imports__
+{
+    uint32_t count;
+    struct
+    {
+        uint32_t kind;
+        char const* alias;
+        uint32_t alias_len;
+        mdToken assembly;
+        char const* target_namespace;
+        uint32_t target_namespace_len;
+        mdToken target_type;
+    } imports[];
+} md_imports_t;
+md_blob_parse_result_t md_parse_imports(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_imports_t* imports, size_t* buffer_len);
 
 // Parse an Edit-and-Continue Local Slot Map blob.
-typedef struct md_enc_local_slot_map__ md_enc_local_slots_map_t;
-bool md_parse_enc_local_slot_map(uint8_t const* blob, size_t blob_len, md_enc_local_slot_map_t* local_slot_map, size_t* buffer_len);
+typedef struct md_enc_local_slot_map__
+{
+    uint32_t syntax_offset_baseline;
+    uint32_t slot_count;
+    struct
+    {
+        uint8_t kind;
+        uint32_t syntax_offset;
+        uint32_t ordinal;
+    } slots[];
+} md_enc_local_slot_map_t;
+md_blob_parse_result_t md_parse_enc_local_slot_map(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_enc_local_slot_map_t* local_slot_map, size_t* buffer_len);
 
 // Parse an Edit-and-Continue Lambda and Closure Map blob.
-typedef struct md_enc_lambda_and_closure_map__ md_enc_lambda_and_closure_map_t;
-bool md_parse_enc_lambda_and_closure_map(uint8_t const* blob, size_t blob_len, md_enc_lambda_and_closure_map_t* lambda_and_closure_map, size_t* buffer_len);
+typedef struct md_enc_lambda_and_closure_map__
+{
+    uint32_t method_ordinal;
+    uint32_t syntax_offset_baseline;
+    uint32_t closure_count;
+    struct closure__
+    {
+        uint32_t syntax_offset;
+    };
+    struct closure__* closure_syntax_offsets;
+    struct
+    {
+        uint32_t syntax_offset;
+        struct closure__* closure;
+    } lambda[];
+} md_enc_lambda_and_closure_map_t;
+md_blob_parse_result_t md_parse_enc_lambda_and_closure_map(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_enc_lambda_and_closure_map_t* lambda_and_closure_map, size_t* buffer_len);
 
 
 #ifdef __cplusplus

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -63,9 +63,9 @@ typedef struct md_local_constant_sig__
 {
     enum
     {
-        PrimitiveConstant,
-        EnumConstant,
-        GeneralConstant
+        mdck_PrimitiveConstant,
+        mdck_EnumConstant,
+        mdck_GeneralConstant
     } constant_kind;
 
     union
@@ -85,16 +85,18 @@ typedef struct md_local_constant_sig__
         {
             enum
             {
-                ValueType,
-                Class,
-                Object
+                mdgc_ValueType,
+                mdgc_Class,
+                mdgc_Object
             } kind;
             mdToken type;
         } general;
     };
 
-    const uint8_t* value_blob;
-    const uint32_t value_len;
+    uint8_t const* value_blob;
+    size_t value_len;
+
+    uint32_t custom_modifier_count;
     
     struct {
         bool required;

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -56,7 +56,7 @@ typedef struct md_sequence_points__
         };
     } records[];
 } md_sequence_points_t;
-md_blob_parse_result_t md_parse_sequence_points(mdcursor_t debug_info_row, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
+md_blob_parse_result_t md_parse_sequence_points(mdcursor_t method_debug_information, uint8_t const* blob, size_t blob_len, md_sequence_points_t* sequence_points, size_t* buffer_len);
 
 // Parse a LocalConstantSig blob.
 typedef struct md_local_constant_sig__

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -111,7 +111,18 @@ typedef struct md_imports__
     uint32_t count;
     struct
     {
-        uint32_t kind;
+        enum
+        {
+            mdidk_ImportNamespace = 1,
+            mdidk_ImportAssemblyNamespace = 2,
+            mdidk_ImportType = 3,
+            mdidk_ImportXmlNamespace = 4,
+            mdidk_ImportAssemblyReferenceAlias = 5,
+            mdidk_AliasAssemblyReference = 6,
+            mdidk_AliasNamespace = 7,
+            mdidk_AliasAssemblyNamespace = 8,
+            mdidk_AliasType = 9,
+        } kind;
         char const* alias;
         uint32_t alias_len;
         mdToken assembly;

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -122,40 +122,6 @@ typedef struct md_imports__
 } md_imports_t;
 md_blob_parse_result_t md_parse_imports(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_imports_t* imports, size_t* buffer_len);
 
-// Parse an Edit-and-Continue Local Slot Map blob.
-typedef struct md_enc_local_slot_map__
-{
-    uint32_t syntax_offset_baseline;
-    uint32_t slot_count;
-    struct
-    {
-        uint8_t kind;
-        uint32_t syntax_offset;
-        uint32_t ordinal;
-    } slots[];
-} md_enc_local_slot_map_t;
-md_blob_parse_result_t md_parse_enc_local_slot_map(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_enc_local_slot_map_t* local_slot_map, size_t* buffer_len);
-
-// Parse an Edit-and-Continue Lambda and Closure Map blob.
-typedef struct md_enc_lambda_and_closure_map__
-{
-    uint32_t method_ordinal;
-    uint32_t syntax_offset_baseline;
-    uint32_t closure_count;
-    struct closure__
-    {
-        uint32_t syntax_offset;
-    };
-    struct closure__* closure_syntax_offsets;
-    struct
-    {
-        uint32_t syntax_offset;
-        struct closure__* closure;
-    } lambda[];
-} md_enc_lambda_and_closure_map_t;
-md_blob_parse_result_t md_parse_enc_lambda_and_closure_map(mdhandle_t handle, uint8_t const* blob, size_t blob_len, md_enc_lambda_and_closure_map_t* lambda_and_closure_map, size_t* buffer_len);
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -78,17 +78,9 @@ set_target_properties(dnmd_interfaces PROPERTIES
   PUBLIC_HEADER ../inc/dnmd_interfaces.hpp
   INTERPROCEDURAL_OPTIMIZATION $<$<NOT:$<CONFIG:DEBUG>>:TRUE>)
   
-install(TARGETS dnmd_interfaces_static EXPORT interfaces_static
+install(TARGETS dnmd_interfaces dnmd_interfaces_static EXPORT interfaces
+  PUBLIC_HEADER DESTINATION include
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)
 
-install(EXPORT interfaces_static NAMESPACE dnmd:: FILE dnmdinterfaces_static.cmake DESTINATION lib/cmake/dnmd)
-
-install(TARGETS dnmd_interfaces EXPORT interfaces
-  PUBLIC_HEADER DESTINATION include
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-
 install(EXPORT interfaces NAMESPACE dnmd:: FILE dnmdinterfaces.cmake DESTINATION lib/cmake/dnmd)
-  

--- a/src/mddump/CMakeLists.txt
+++ b/src/mddump/CMakeLists.txt
@@ -10,8 +10,6 @@ target_link_libraries(mddump
   dnmd::pdb
   dncp::dncp)
 
-target_compile_definitions(mddump PRIVATE DNMD_PORTABLE_PDB)
-
 if(NOT MSVC)
   target_link_libraries(mddump dncp::winhdrs)
 endif()

--- a/src/mddump/CMakeLists.txt
+++ b/src/mddump/CMakeLists.txt
@@ -7,8 +7,10 @@ add_executable(mddump
 )
 
 target_link_libraries(mddump
-  dnmd::dnmd
+  dnmd::pdb
   dncp::dncp)
+
+target_compile_definitions(mddump PRIVATE DNMD_PORTABLE_PDB)
 
 if(NOT MSVC)
   target_link_libraries(mddump dncp::winhdrs)


### PR DESCRIPTION
As part of this work, I also added a separate target for referencing a version of DNMD with portable PDB support enabled (exported as dnmd::pdb).

This implements all of the blob formats specified in the Portable PDB Spec 1.0 not in the CustomDebugInformation section.

Fixes #36 as much as we plan to.